### PR TITLE
Allow OIDC to create EC2 tags

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -259,6 +259,7 @@ module "oidc_services_policy" {
     "service_discovery_read",
     "ecs_write",
     "ec2",
+    "launch_template_update",
     "acm_read",
     "iam_read",
     "ssm_read",


### PR DESCRIPTION
Giving the launch template update permission allows the OIDC deployments to create EC2 tags, and to setup launch templates.  This is important for the first-time deployment via OIDC. Historically, the first deployment will have been manual, from a laptop, and the Engineer would have had the correct permissions.  This commit give the permissions needed to OIDC, so that GitHub can bootstrap a service.