### PR TITLE
Allow OIDC action for Creator

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-2
+3

--- a/.github/workflows/prod_pr_merged.yml
+++ b/.github/workflows/prod_pr_merged.yml
@@ -49,9 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Kosli cli
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION}}
+        uses: cyber-dojo/setup-kosli-cli@main
 
       - name: Download a single artifact
         uses: actions/download-artifact@v4.1.1

--- a/.github/workflows/prod_pr_open.yml
+++ b/.github/workflows/prod_pr_open.yml
@@ -27,9 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Kosli cli
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
+        uses: cyber-dojo/setup-kosli-cli@main
 
       - name: Create Kosli flow for terraform-base-infra PRs
         run:

--- a/.github/workflows/prod_pr_open.yml
+++ b/.github/workflows/prod_pr_open.yml
@@ -24,22 +24,7 @@ jobs:
           contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Kosli cli
-        uses: cyber-dojo/setup-kosli-cli@main
-
-      - name: Create Kosli flow for terraform-base-infra PRs
-        run:
-          kosli create flow ${{ env.KOSLI_FLOW }}
-            --template-file kosli-trail-template.yml
-            --description "Kosli flow to track terraform PRs for base infra"
-
-      - name: Create Kosli trail for terraform-base-infra PRs
-        run:
-          kosli begin trail ${{ env.KOSLI_TRAIL }}
-            --flow ${{ env.KOSLI_FLOW }}
-            --template-file kosli-trail-template.yml
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials for terraform validation
         id: configure-aws-creds
@@ -65,21 +50,8 @@ jobs:
           terraform validate -json > validation_results.json
           echo "KOSLI_TF_VALIDATION_COMPLIANT=$(jq -r '.valid' ./validation_results.json)" >> ${GITHUB_ENV}
 
-      - name: Attest terraform validation results to Kosli trail
-        run:
-          kosli attest generic
-            --name tf-validation
-            --flow ${{ env.KOSLI_FLOW }}
-            --trail ${{ env.KOSLI_TRAIL }}
-            --compliant=${{ env.KOSLI_TF_VALIDATION_COMPLIANT }}
-
-      - name: Upload validation results as artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: validation_results
-          path: ./validation_results.json
-
   plan:
+    needs: [ begin-trail ]
     permissions:
       id-token: write
       contents: write
@@ -96,33 +68,9 @@ jobs:
       tf_upload_artifact_plan: 'true'
       tf_upload_artifact_name_suffix: "_prod"
 
-  trail-attest-tf-plan:
-    needs: [  begin-trail, plan ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup kosli cli
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Download terraform plan created in the plan job
-        uses: actions/download-artifact@v4.1.1
-        with:
-          name: tf_artifacts_plan_prod
-
-      - name: Attest tf plan to Kosli trail
-        run:
-          kosli attest generic
-            --name tf-plan
-            --flow ${{ env.KOSLI_FLOW }}
-            --trail ${{ env.KOSLI_TRAIL }}
-
   # Cleanup workflow artifacts
   cleanup-workflow-artifacts:
-    needs: [ trail-attest-tf-plan ]
+    needs: [ plan ]
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
In order to roll out the migrated Creator app, we need to grant "Create Tag" permissions to the GitHub OIDC connection -- and to support this I have simplified some of the steps in the production plan workflow.