### PR TITLE
Add tf drift detection for staging

### DIFF
--- a/.github/workflows/detect-drift.yml
+++ b/.github/workflows/detect-drift.yml
@@ -1,0 +1,32 @@
+name: 'Detect Drift'
+
+on:
+  schedule:
+    - cron: '20 6,18 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  detect-drift:
+    permissions:
+      id-token: write
+      contents: write
+    uses: kosli-dev/tf/.github/workflows/detect-drift.yml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - aws_account_id: 244531986313
+            environment: beta
+            name: beta
+          - aws_account_id: 274425519734
+            environment: prod
+            name: prod
+    name: ${{ matrix.name }}
+    with:
+      aws_region: eu-central-1
+      aws_role_arn: "arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ github.event.repository.name }}"
+      environment: ${{ matrix.environment }}
+      tf_version: v1.14.9

--- a/drift-detection.tf
+++ b/drift-detection.tf
@@ -1,0 +1,12 @@
+module "tf_statefile_paths_reporter" {
+  source = "./drift-detection"
+
+  name                   = "terraform-statefile-paths-reporter"
+  env                    = var.env_name
+  kosli_environment_name = "terraform-drift-detection-${var.env_name}"
+  kosli_host             = var.kosli_api_host
+  kosli_cli_version      = "v2.18.0"
+  kosli_org              = "cyber-dojo"
+  schedule_expression    = var.drift_detection_schedule
+  s3_bucket_name         = local.state_bucket_name
+}

--- a/drift-detection/data.tf
+++ b/drift-detection/data.tf
@@ -1,0 +1,3 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}

--- a/drift-detection/eventbridge.tf
+++ b/drift-detection/eventbridge.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_event_rule" "cron" {
+  name        = "${var.name}-cron"
+  description = "Trigger ${var.name} on a schedule"
+
+  schedule_expression = var.schedule_expression
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "cron" {
+  arn       = module.reporter_lambda.lambda_function_arn
+  rule      = aws_cloudwatch_event_rule.cron.name
+  target_id = "${module.reporter_lambda.lambda_function_name}-cron"
+}

--- a/drift-detection/iam.tf
+++ b/drift-detection/iam.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "s3_read_allow" {
+  statement {
+    sid    = "S3Read"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}",
+      "arn:aws:s3:::${var.s3_bucket_name}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "ssm_read_allow" {
+  statement {
+    sid    = "SSMRead"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+    ]
+    resources = [
+      local.kosli_api_token_ssm_parameter_arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "kms_decrypt_allow" {
+  statement {
+    sid    = "KMSDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.kosli_api_token_kms_key_arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "combined" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.s3_read_allow.json,
+    data.aws_iam_policy_document.ssm_read_allow.json,
+    data.aws_iam_policy_document.kms_decrypt_allow.json,
+  ]
+}

--- a/drift-detection/lambda-src/main.py
+++ b/drift-detection/lambda-src/main.py
@@ -1,0 +1,98 @@
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import boto3
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ssm_client = boto3.client('ssm')
+s3_client = boto3.client('s3')
+
+ssm_parameter_arn = os.environ['KOSLI_API_TOKEN_SSM_PARAMETER_ARN']
+
+try:
+    response = ssm_client.get_parameter(Name=ssm_parameter_arn, WithDecryption=True)
+    kosli_api_token = response['Parameter']['Value']
+except Exception as e:
+    logger.error(f"Error retrieving SSM parameter: {e}")
+    raise
+
+WORKDIR = Path('/tmp/kosli-paths')
+PATHS_FILE_NAME = os.environ['PATHS_FILE']
+PATHS_FILE_SRC = Path(__file__).parent / PATHS_FILE_NAME
+
+
+def parse_paths_file(text):
+    # Minimal parser for the fixed paths-file schema:
+    #   version: 1
+    #   artifacts:
+    #     <name>:
+    #       path: <s3-key>
+    paths = []
+    in_artifacts = False
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith('#'):
+            continue
+        if not line.startswith(' '):
+            in_artifacts = line.strip() == 'artifacts:'
+            continue
+        if not in_artifacts:
+            continue
+        m = re.match(r'\s+path:\s*(.+?)\s*$', line)
+        if m:
+            paths.append(m.group(1).strip().strip('"').strip("'"))
+    return paths
+
+
+def lambda_handler(event, context):
+    bucket = os.environ['S3_BUCKET_NAME']
+    env_name = os.environ['KOSLI_ENVIRONMENT_NAME']
+
+    WORKDIR.mkdir(parents=True, exist_ok=True)
+
+    paths_file_dst = WORKDIR / PATHS_FILE_NAME
+    paths_file_dst.write_bytes(PATHS_FILE_SRC.read_bytes())
+
+    keys = parse_paths_file(PATHS_FILE_SRC.read_text())
+    if not keys:
+        logger.error("No artifact paths found in %s", PATHS_FILE_SRC)
+        return {"statusCode": 500, "body": "No artifact paths in paths-file"}
+
+    for key in keys:
+        local = WORKDIR / key
+        local.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("downloading s3://%s/%s -> %s", bucket, key, local)
+        s3_client.download_file(bucket, key, str(local))
+
+    env = os.environ.copy()
+    env['KOSLI_API_TOKEN'] = kosli_api_token
+
+    cmd = [
+        '/opt/kosli', 'snapshot', 'paths', env_name,
+        f'--paths-file=./{PATHS_FILE_NAME}',
+    ]
+    logger.info("running: %s (cwd=%s)", ' '.join(cmd), WORKDIR)
+    result = subprocess.run(
+        cmd,
+        cwd=str(WORKDIR),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    stdout = result.stdout.decode('utf-8')
+    stderr = result.stderr.decode('utf-8')
+    if stdout:
+        logger.info(stdout)
+    if stderr:
+        logger.error(stderr)
+
+    if result.returncode != 0:
+        return {"statusCode": 500, "body": stderr or "kosli command failed"}
+    return {"statusCode": 200, "body": stdout}

--- a/drift-detection/main.tf
+++ b/drift-detection/main.tf
@@ -1,0 +1,69 @@
+locals {
+  paths_file_name                   = "path.file.${var.env}.yml"
+  kosli_api_token_ssm_parameter_arn = var.kosli_api_token_ssm_parameter_arn == "" ? "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/kosli_api_token" : var.kosli_api_token_ssm_parameter_arn
+}
+
+data "http" "cli_to_layer_mapping" {
+  url = "https://lambda-layer-mapping-ccc19615fd6c05ace42e71c551995458dbdb1be7.s3.eu-central-1.amazonaws.com/lambda_layer_versions.json"
+}
+
+locals {
+  kosli_cli_layer_arn = jsondecode(data.http.cli_to_layer_mapping.response_body)[var.kosli_cli_version][data.aws_region.current.region]
+}
+
+module "reporter_lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  attach_policy_json = true
+  policy_json        = data.aws_iam_policy_document.combined.json
+
+  function_name = var.name
+  description   = "Runs `kosli snapshot paths` against ${var.kosli_environment_name}"
+  handler       = "main.lambda_handler"
+  runtime       = "python3.11"
+
+  role_name      = var.name
+  timeout        = var.lambda_timeout
+  create_package = true
+  publish        = true
+
+  layers = [
+    local.kosli_cli_layer_arn,
+  ]
+
+  source_path = [
+    {
+      path = "${path.module}/lambda-src"
+      commands = [
+        ":zip"
+      ]
+    },
+    {
+      path = "${path.module}/${local.paths_file_name}"
+      commands = [
+        ":zip"
+      ]
+    }
+  ]
+
+  environment_variables = {
+    KOSLI_ENVIRONMENT_NAME            = var.kosli_environment_name
+    KOSLI_HOST                        = var.kosli_host
+    KOSLI_ORG                         = var.kosli_org
+    KOSLI_API_TOKEN_SSM_PARAMETER_ARN = local.kosli_api_token_ssm_parameter_arn
+    S3_BUCKET_NAME                    = var.s3_bucket_name
+    PATHS_FILE                        = local.paths_file_name
+  }
+
+  allowed_triggers = {
+    AllowExecutionFromCloudWatchCron = {
+      principal  = "events.amazonaws.com"
+      source_arn = aws_cloudwatch_event_rule.cron.arn
+    }
+  }
+
+  cloudwatch_logs_retention_in_days = var.cloudwatch_logs_retention_in_days
+
+  tags = var.tags
+}

--- a/drift-detection/outputs.tf
+++ b/drift-detection/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_arn" {
+  description = "ARN of the reporter lambda function."
+  value       = module.reporter_lambda.lambda_function_arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the reporter lambda function."
+  value       = module.reporter_lambda.lambda_function_name
+}

--- a/drift-detection/path.file.prod.yml
+++ b/drift-detection/path.file.prod.yml
@@ -1,0 +1,37 @@
+version: 1
+artifacts:
+
+  creator-state:
+    path: terraform/creator/main.tfstate
+
+  custom-start-points-state:
+    path: terraform/custom-start-points/main.tfstate
+
+  dashboard-state:
+    path: terraform/dashboard/main.tfstate
+
+  differ-state:
+    path: terraform/differ/differ.tfstate
+
+  exercises-start-points-state:
+    path: terraform/exercises-start-points/main.tfstate
+
+  languages-start-points-state:
+    path: terraform/languages-start-points/main.tfstate
+
+  nginx-state:
+    path: terraform/nginx/main.tfstate
+
+  runner-state:
+    path: terraform/runner/main.tfstate
+
+  saver-state:
+    path: terraform/saver/saver.tfstate
+
+  web-state:
+    path: terraform/web/main.tfstate
+
+  terraform-base-infra-state:
+    path: terraform/terraform-base-infra/main.tfstate
+  terraform-base-infra-drift:
+    path: terraform/terraform-base-infra/drift.plan.json

--- a/drift-detection/path.file.staging.yml
+++ b/drift-detection/path.file.staging.yml
@@ -1,0 +1,37 @@
+version: 1
+artifacts:
+
+  creator-state:
+    path: terraform/creator/main.tfstate
+
+  custom-start-points-state:
+    path: terraform/custom-start-points/main.tfstate
+
+  dashboard-state:
+    path: terraform/dashboard/main.tfstate
+
+  differ-state:
+    path: terraform/differ/differ.tfstate
+
+  exercises-start-points-state:
+    path: terraform/exercises-start-points/main.tfstate
+
+  languages-start-points-state:
+    path: terraform/languages-start-points/main.tfstate
+
+  nginx-state:
+    path: terraform/nginx/main.tfstate
+
+  runner-state:
+    path: terraform/runner/main.tfstate
+
+  saver-state:
+    path: terraform/saver/saver.tfstate
+
+  web-state:
+    path: terraform/web/main.tfstate
+
+  terraform-base-infra-state:
+    path: terraform/terraform-base-infra/main.tfstate
+  terraform-base-infra-drift:
+    path: terraform/terraform-base-infra/drift.plan.json

--- a/drift-detection/variables.tf
+++ b/drift-detection/variables.tf
@@ -1,0 +1,73 @@
+variable "name" {
+  type        = string
+  description = "The name for the Reporter AWS resources (lambda, role, eventbridge rule)."
+}
+
+variable "env" {
+  type        = string
+  description = "Environment name (e.g. beta, prod). Selects path.file.<env>.yml from this module's directory; the file must exist or terraform plan will fail."
+}
+
+variable "kosli_environment_name" {
+  type        = string
+  description = "The Kosli environment name to snapshot into. The lambda runs `kosli snapshot paths <kosli_environment_name>`."
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "The S3 bucket containing the files to fingerprint. The lambda needs read access to it."
+}
+
+variable "kosli_host" {
+  type        = string
+  default     = "https://app.kosli.com"
+  description = "The Kosli endpoint."
+}
+
+variable "kosli_org" {
+  type        = string
+  description = "Kosli organisation name (the value for the cli --org parameter)."
+  default     = "kosli"
+}
+
+variable "kosli_cli_version" {
+  type        = string
+  description = "The Kosli cli version, in the format v2.18.0. Used to look up the lambda layer ARN."
+  default     = "v2.18.0"
+}
+
+variable "schedule_expression" {
+  type        = string
+  default     = "rate(10 minutes)"
+  description = "EventBridge schedule expression that triggers the lambda. E.g. `rate(10 minutes)` or `cron(0 * * * ? *)`."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to assign to the reporter AWS resources."
+  default     = {}
+}
+
+variable "lambda_timeout" {
+  type        = number
+  default     = 60
+  description = "The amount of time the lambda has to run in seconds."
+}
+
+variable "cloudwatch_logs_retention_in_days" {
+  type        = number
+  default     = 7
+  description = "The retention period of lambda logs (days)."
+}
+
+variable "kosli_api_token_ssm_parameter_arn" {
+  type        = string
+  description = "ARN of the Kosli API token SSM parameter. If empty, defaults to the `kosli_api_token` parameter in the current account/region."
+  default     = ""
+}
+
+variable "kosli_api_token_kms_key_arn" {
+  type        = string
+  description = "ARN of the KMS key used to encrypt the Kosli API token SSM parameter."
+  default     = "*"
+}

--- a/drift-detection/versions.tf
+++ b/drift-detection/versions.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.51.0"
+      source = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -31,6 +31,16 @@ module "terraform_base_infra_policy" {
 
 data "aws_iam_policy_document" "oidc_terraform_base_infra_additional_policy" {
   statement {
+    sid    = "ManageEventSchedules"
+    effect = "Allow"
+    actions = [
+      "events:*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+  statement {
     sid    = "S3PutBucketNotification"
     effect = "Allow"
     actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -293,6 +293,18 @@ data "aws_iam_policy_document" "oidc_services_additional_policy" {
     ]
   }
   statement {
+    sid    = "S3BackendLock"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "${module.state_bucket.s3_bucket_arn}/*.tflock"
+    ]
+  }
+  statement {
     sid    = "S3Write"
     effect = "Allow"
     actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,14 @@ variable "grafana_account_id" {
   type    = string
   default = "855032297737"
 }
+
+variable "kosli_api_host" {
+  type    = string
+  default = "https://app.kosli.com,https://staging.app.kosli.com,https://app.us.kosli.com"
+}
+
+variable "drift_detection_schedule" {
+  type        = string
+  description = "EventBridge schedule expression that controls how often the statefile drift-detection Lambda runs."
+  default     = "rate(10 minutes)"
+}


### PR DESCRIPTION
This PR adds the basic drift detection for CyberDojo, capturing the "drift detection" file for terraform base infra and capturing the statefile for all terraform stacks.

At present, none of the stacks are using our `tf` tools, and so none of these statefiles have provenance, but that's the next step.