### PR TITLE
Remove Differ from drift detection

### DIFF
--- a/drift-detection/path.file.beta.yml
+++ b/drift-detection/path.file.beta.yml
@@ -10,8 +10,11 @@ artifacts:
   dashboard-state:
     path: terraform/dashboard/main.tfstate
 
-  differ-state:
-    path: terraform/differ/differ.tfstate
+  # differ has a different deployment model to the other services
+  # so we will remove it from drift detection until we have the
+  # other services fully detecting drift in production
+  #differ-state:
+  #  path: terraform/differ/differ.tfstate
 
   exercises-start-points-state:
     path: terraform/exercises-start-points/main.tfstate

--- a/drift-detection/path.file.prod.yml
+++ b/drift-detection/path.file.prod.yml
@@ -10,8 +10,11 @@ artifacts:
   dashboard-state:
     path: terraform/dashboard/main.tfstate
 
-  differ-state:
-    path: terraform/differ/differ.tfstate
+  # differ has a different deployment model to the other services
+  # so we will remove it from drift detection until we have the
+  # other services fully detecting drift in production
+  #differ-state:
+  #  path: terraform/differ/differ.tfstate
 
   exercises-start-points-state:
     path: terraform/exercises-start-points/main.tfstate


### PR DESCRIPTION
The mechanism for building, testing and deploying "differ" is different to the other CyberDojo services, and so we are removing it from drift detection for now, whilst we make the necessary tooling adjustments for it.