### PR TITLE
Add checkout step to beta Kosli attest decision job

### DIFF
--- a/.github/workflows/beta-pr-merged.yml
+++ b/.github/workflows/beta-pr-merged.yml
@@ -41,6 +41,8 @@ jobs:
       KOSLI_FLOW: ${{ needs.apply.outputs.kosli_flow }}
       KOSLI_TRAIL: ${{ needs.apply.outputs.kosli_trail }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup Kosli CLI
         uses: kosli-dev/setup-cli-action@060e7f9bf6ac246743d6a62c5df847dfe7050867 # v5.2.1
 


### PR DESCRIPTION
The kosli attest command reads commit information from the .git folder, so the job needs the repository checked out before running.