### PR TITLE
Add drift detection for several services

### DIFF
--- a/drift-detection/path.file.beta.yml
+++ b/drift-detection/path.file.beta.yml
@@ -24,12 +24,18 @@ artifacts:
 
   nginx-state:
     path: terraform/nginx/main.tfstate
+  nginx-drift:
+    path: terraform/nginx/.plan.json
 
   runner-state:
     path: terraform/runner/main.tfstate
+  runner-drift:
+    path: terraform/runner/drift.plan.json
 
   saver-state:
-    path: terraform/saver/saver.tfstate
+    path: terraform/saver/main.tfstate
+  saver-drift:
+    path: terraform/saver/drift.plan.json
 
   web-state:
     path: terraform/web/main.tfstate

--- a/drift-detection/path.file.prod.yml
+++ b/drift-detection/path.file.prod.yml
@@ -24,15 +24,23 @@ artifacts:
 
   nginx-state:
     path: terraform/nginx/main.tfstate
+  nginx-drift:
+    path: terraform/nginx/.plan.json
 
   runner-state:
     path: terraform/runner/main.tfstate
+  runner-drift:
+    path: terraform/runner/drift.plan.json
 
   saver-state:
-    path: terraform/saver/saver.tfstate
+    path: terraform/saver/main.tfstate
+  saver-drift:
+    path: terraform/saver/drift.plan.json
 
   web-state:
     path: terraform/web/main.tfstate
+  web-drift:
+    path: terraform/web/drift.plan.json
 
   terraform-base-infra-state:
     path: terraform/terraform-base-infra/main.tfstate

--- a/variables.tf
+++ b/variables.tf
@@ -107,5 +107,5 @@ variable "kosli_api_host" {
 variable "drift_detection_schedule" {
   type        = string
   description = "EventBridge schedule expression that controls how often the statefile drift-detection Lambda runs."
-  default     = "rate(10 minutes)"
+  default     = "rate(5 minutes)"
 }


### PR DESCRIPTION
Now that some of the services have been deployed to production, we can turn on drift detection for them.

To give faster feedback, I've shorted the delay in the drift detection lambda - now runs once every five minutes, rather than once every 10.