### PR TITLE
Skip snapshot when a fingerprinted file may not be attested yet

### DIFF
--- a/drift-detection/lambda-src/main.py
+++ b/drift-detection/lambda-src/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 import boto3
@@ -25,6 +26,12 @@ except Exception as e:
 WORKDIR = Path('/tmp/kosli-paths')
 PATHS_FILE_NAME = os.environ['PATHS_FILE']
 PATHS_FILE_SRC = Path(__file__).parent / PATHS_FILE_NAME
+
+# Files written to S3 more recently than this may not have been attested to
+# Kosli yet (the pipelines write the file first, then attest it). Reporting
+# such a file would flag the environment as non-compliant, so we skip the
+# whole snapshot and let the next scheduled run report it instead.
+MIN_ARTIFACT_AGE_SECONDS = int(os.environ.get('MIN_ARTIFACT_AGE_SECONDS', '180'))
 
 
 def parse_paths_file(text):
@@ -68,7 +75,19 @@ def lambda_handler(event, context):
         local = WORKDIR / key
         local.parent.mkdir(parents=True, exist_ok=True)
         logger.info("downloading s3://%s/%s -> %s", bucket, key, local)
-        s3_client.download_file(bucket, key, str(local))
+        # get_object (not download_file) so that LastModified describes the
+        # same bytes we fingerprint, avoiding a check-then-download race.
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+        age = (datetime.now(timezone.utc) - obj['LastModified']).total_seconds()
+        if age < MIN_ARTIFACT_AGE_SECONDS:
+            msg = (
+                f"s3://{bucket}/{key} was modified {age:.0f}s ago "
+                f"(< {MIN_ARTIFACT_AGE_SECONDS}s); its attestation may not have "
+                "landed yet. Skipping this snapshot; the next run will report it."
+            )
+            logger.warning(msg)
+            return {"statusCode": 200, "body": msg}
+        local.write_bytes(obj['Body'].read())
 
     env = os.environ.copy()
     env['KOSLI_API_TOKEN'] = kosli_api_token

--- a/drift-detection/main.tf
+++ b/drift-detection/main.tf
@@ -74,6 +74,7 @@ module "reporter_lambda" {
     KOSLI_API_TOKEN_SSM_PARAMETER_ARN = local.kosli_api_token_ssm_parameter_arn
     S3_BUCKET_NAME                    = var.s3_bucket_name
     PATHS_FILE                        = local.paths_file_name
+    MIN_ARTIFACT_AGE_SECONDS          = var.min_artifact_age_seconds
   }
 
   allowed_triggers = {

--- a/drift-detection/variables.tf
+++ b/drift-detection/variables.tf
@@ -5,7 +5,7 @@ variable "name" {
 
 variable "env" {
   type        = string
-  description = "Environment name (e.g. beta, prod). Selects path.file.<env>.yml from this module's directory; the file must exist or terraform plan will fail."
+  description = "Environment name (e.g. staging, prod, infra-dev). Selects path.file.<env>.yml from this module's directory; the file must exist or terraform plan will fail."
 }
 
 variable "kosli_environment_name" {
@@ -64,6 +64,12 @@ variable "kosli_api_token_ssm_parameter_arn" {
   type        = string
   description = "ARN of the Kosli API token SSM parameter. If empty, defaults to the `kosli_api_token` parameter in the current account/region."
   default     = ""
+}
+
+variable "min_artifact_age_seconds" {
+  type        = number
+  default     = 180
+  description = "Skip the snapshot if any fingerprinted S3 object was modified more recently than this. Guards against reporting a statefile (or drift plan) whose attestation has not landed yet. Must exceed the pipelines' write-to-attest latency and be less than the snapshot schedule interval."
 }
 
 variable "kosli_api_token_kms_key_arn" {


### PR DESCRIPTION
The pipelines that write statefiles and drift plans to S3 attest them to Kosli only after the write, so there is a window in which a snapshot would fingerprint a file whose attestation has not landed, and Kosli would flag the environment as non-compliant.

The lambda now checks the age of every object it downloads and, if any was modified less than MIN_ARTIFACT_AGE_SECONDS ago (default 180, configurable via the new min_artifact_age_seconds module variable), skips the whole snapshot and lets the next scheduled run report it. The age comes from the same get_object response as the bytes we fingerprint, so there is no check-then-download race. Skipping the entire snapshot, rather than just the fresh file, avoids the artifact appearing to be removed and re-added across consecutive snapshots.

If a file is never attested it will still be reported once it is older than the threshold, so genuinely unattested out-of-band changes are still flagged.