### PR TITLE
Ignore GitHub OIDC provider thumbprint changes to prevent plan drift

### DIFF
--- a/github_oidc.tf
+++ b/github_oidc.tf
@@ -2,6 +2,25 @@ resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.tls_certificate.github_actions_oidc_provider.certificates[0].sha1_fingerprint]
+
+  lifecycle {
+    # thumbprint_list is derived from data.tls_certificate below, which reads the
+    # live TLS certificate of token.actions.githubusercontent.com on every plan.
+    # GitHub rotates that certificate periodically, so its sha1 fingerprint moves
+    # with the rotation rather than with any real config change, and each daily
+    # drift-detection `tf plan` flags the new fingerprint as drift.
+    #
+    # AWS validates GitHub's OIDC tokens for this well-known provider against its
+    # trusted root-CA store, not against this stored thumbprint, so a stale value
+    # here does not affect authentication: role assumption via this provider keeps
+    # working across rotations. Ignore the attribute to stop the false drift.
+    #
+    # NOTE: This ignore is permanent. If you ever need AWS to hold the current
+    # certificate thumbprint again, temporarily remove `thumbprint_list` from
+    # ignore_changes below (apply, then add it back), or run
+    # `terraform apply -replace` on this resource.
+    ignore_changes = [thumbprint_list]
+  }
 }
 
 data "tls_certificate" "github_actions_oidc_provider" {


### PR DESCRIPTION
The GitHub OIDC provider's thumbprint_list is derived from a live tls_certificate lookup, so it changes whenever GitHub rotates the token.actions.githubusercontent.com certificate. That surfaced as recurring drift in the daily detect-drift plan and flipped the aws-beta/aws-prod terraform-drift-detection environments to non-compliant with no real change. AWS validates this well-known provider against its trusted root-CA store rather than the stored thumbprint, so the value is safe to freeze. Adds a lifecycle ignore_changes for thumbprint_list, matching the image_id pattern from PR #55. A follow-up master -> prod PR will clear prod.