### PR TITLE
Trust cyber-dojo/spooler to assume the gh_actions_services role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -359,6 +359,7 @@ module "oidc_services_role" {
     "cyber-dojo/runner",
     "cyber-dojo/saver",
     "cyber-dojo/shas",
+    "cyber-dojo/spooler",
     "cyber-dojo/web",
     "cyber-dojo/version-reporter",
     "cyber-dojo/versioner",


### PR DESCRIPTION
  The new spooler repo's CI (build-image via secure-docker-build) assumes
  gh_actions_services via GitHub OIDC to push its image to ECR. That role
  trusts an explicit repo allow-list, and spooler was absent, so the assume
  was rejected:

    Could not assume role with OIDC: Not authorized to perform
    sts:AssumeRoleWithWebIdentity

  Add cyber-dojo/spooler to oidc_repos_list so its OIDC token is accepted.