### PR TITLE
Grant gh_actions_services write access to spooler's terraform state

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -322,6 +322,7 @@ data "aws_iam_policy_document" "oidc_services_additional_policy" {
       "${module.state_bucket.s3_bucket_arn}/terraform/nginx*",
       "${module.state_bucket.s3_bucket_arn}/terraform/repler*",
       "${module.state_bucket.s3_bucket_arn}/terraform/runner*",
+      "${module.state_bucket.s3_bucket_arn}/terraform/spooler*",
       "${module.state_bucket.s3_bucket_arn}/terraform/saver*",
       "${module.state_bucket.s3_bucket_arn}/terraform/web*",
       "${module.state_bucket.s3_bucket_arn}/terraform/version-reporter*"


### PR DESCRIPTION
  The deploy-to-beta job in spooler's CI runs terraform against the shared
  state bucket, reading and writing its state at terraform/spooler*. The
  gh_actions_services permissions policy enumerates one state path per
  service, and spooler was absent, so its deploy would fail with
  access-denied on state once the pipeline reaches that stage.

  Add the spooler path, mirroring the existing services (differ, saver,
  etc.). This is the state-bucket permission for the deploy stage; it is
  separate from the trust-policy grant (oidc_repos_list) that lets the
  role be assumed.