### PR TITLE
Match spooler's immutable OIDC subject so it can assume gh_actions_se…

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -360,7 +360,10 @@ module "oidc_services_role" {
     "cyber-dojo/runner",
     "cyber-dojo/saver",
     "cyber-dojo/shas",
-    "cyber-dojo/spooler",
+    # spooler was created after GitHub enabled immutable OIDC subject claims, so
+    # its token subject embeds the numeric org and repo ids instead of the plain
+    # cyber-dojo/spooler path. The trust must match that immutable form.
+    "cyber-dojo@19868796/spooler@1304186901",
     "cyber-dojo/web",
     "cyber-dojo/version-reporter",
     "cyber-dojo/versioner",


### PR DESCRIPTION
…rvices

  GitHub recently enabled immutable subject claims for Actions OIDC tokens.
  Repositories created after that (spooler is one) present a subject of the
  form repo:cyber-dojo@<org-id>/spooler@<repo-id>:* rather than the plain
  repo:cyber-dojo/spooler:* that older repos (saver, differ, ...) still use.

  The trust entry was written for the plain form, so it never matched the
  token spooler actually presents, and STS refused AssumeRoleWithWebIdentity.
  That blocked spooler's CI at the "Configure AWS credentials" step, before
  it could log in to push its image to ECR.

  Use spooler's immutable subject in oidc_repos_list so the trust matches.