### PR TITLE
Stop pinning GitHub OIDC TLS thumbprint

### DIFF
--- a/github_oidc.tf
+++ b/github_oidc.tf
@@ -1,28 +1,4 @@
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.github_actions_oidc_provider.certificates[0].sha1_fingerprint]
-
-  lifecycle {
-    # thumbprint_list is derived from data.tls_certificate below, which reads the
-    # live TLS certificate of token.actions.githubusercontent.com on every plan.
-    # GitHub rotates that certificate periodically, so its sha1 fingerprint moves
-    # with the rotation rather than with any real config change, and each daily
-    # drift-detection `tf plan` flags the new fingerprint as drift.
-    #
-    # AWS validates GitHub's OIDC tokens for this well-known provider against its
-    # trusted root-CA store, not against this stored thumbprint, so a stale value
-    # here does not affect authentication: role assumption via this provider keeps
-    # working across rotations. Ignore the attribute to stop the false drift.
-    #
-    # NOTE: This ignore is permanent. If you ever need AWS to hold the current
-    # certificate thumbprint again, temporarily remove `thumbprint_list` from
-    # ignore_changes below (apply, then add it back), or run
-    # `terraform apply -replace` on this resource.
-    ignore_changes = [thumbprint_list]
-  }
-}
-
-data "tls_certificate" "github_actions_oidc_provider" {
-  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
 }


### PR DESCRIPTION
The aws_iam_openid_connect_provider previously derived its thumbprint_list from a data.tls_certificate that read the live TLS certificate of token.actions.githubusercontent.com on every plan, with an ignore_changes lifecycle to suppress the drift caused by GitHub rotating that certificate.

This was a workaround from before AWS added GitHub to its trusted root CAs. Since 2023 AWS validates GitHub's OIDC tokens against its trusted root-CA store rather than a pinned thumbprint, and the current AWS provider (6.51.0) makes thumbprint_list optional. The data source, thumbprint_list, and lifecycle block are therefore no longer needed.